### PR TITLE
Override begin() method to facilitate the declaration of alternate SD…

### DIFF
--- a/Adafruit_AM2320.cpp
+++ b/Adafruit_AM2320.cpp
@@ -51,7 +51,7 @@
 #include "Adafruit_AM2320.h"
 
   /**************************************************************************/
-  /*! 
+  /*!
       @brief  Instantiates a new AM2320 class
       @param theI2C Optional pointer to a TwoWire object that should be used for I2C communication. Defaults to &Wire.
       @param tempSensorId the id that should be used for the temperature sensor. Defaults to -1
@@ -65,8 +65,8 @@ Adafruit_AM2320::Adafruit_AM2320(TwoWire *theI2C, int32_t tempSensorId, int32_t 
 {}
 
 /**************************************************************************/
-/*! 
-    @brief  Setups the hardware
+/*!
+    @brief  Setups the hardware using default SDA and SCL pins
     @return true
 */
 /**************************************************************************/
@@ -77,7 +77,20 @@ bool Adafruit_AM2320::begin() {
 }
 
 /**************************************************************************/
-/*! 
+/*!
+    @brief  Setups the hardware specifying alternate SDA and SCL pins
+    @return true
+*/
+/**************************************************************************/
+
+bool Adafruit_AM2320::begin(int sda, int scl) {
+  _i2caddr = 0x5C;  // fixed addr
+  _i2c->begin(sda,scl);
+  return true;
+}
+
+/**************************************************************************/
+/*!
     @brief  read the temperature from the device
     @return the temperature reading as a floating point value
 */
@@ -97,7 +110,7 @@ float Adafruit_AM2320::readTemperature() {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  read the humidity from the device
     @return the humidity reading as a floating point value
 */
@@ -111,7 +124,7 @@ float Adafruit_AM2320::readHumidity() {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  read 2 bytes from a hardware register
     @param reg the register to read
     @return the read value as a 2 byte unsigned integer
@@ -132,12 +145,12 @@ uint16_t Adafruit_AM2320::readRegister16(uint8_t reg) {
   Wire.endTransmission();
 
   delay(2);  // wait 2 ms
-  
+
   // 2 bytes preamble, 2 bytes data, 2 bytes CRC
   Wire.requestFrom(_i2caddr, (uint8_t)6);
   if (Wire.available() != 6)
     return 0xFFFF;
-  
+
   uint8_t buffer[6];
   for (int i=0; i<6; i++) {
     buffer[i] = Wire.read();
@@ -146,7 +159,7 @@ uint16_t Adafruit_AM2320::readRegister16(uint8_t reg) {
 
   if (buffer[0] != 0x03)   return 0xFFFF; // must be 0x03 modbus reply
   if (buffer[1] != 2)      return 0xFFFF; // must be 2 bytes reply
-  
+
   uint16_t the_crc = buffer[5];
   the_crc <<= 8;
   the_crc |= buffer[4];
@@ -164,7 +177,7 @@ uint16_t Adafruit_AM2320::readRegister16(uint8_t reg) {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  perfor a CRC check to verify data
     @param buffer the pointer to the data to check
     @param nbytes the number of bytes to calculate the CRC over
@@ -189,7 +202,7 @@ uint16_t Adafruit_AM2320::crc16(uint8_t *buffer, uint8_t nbytes) {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  set the name of the sensor
     @param sensor a pointer to the sensor
 */
@@ -199,7 +212,7 @@ void Adafruit_AM2320::setName(sensor_t* sensor) {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  set minimum delay to a fixed value of 2 seconds
     @param sensor a pointer to the sensor
 */
@@ -209,7 +222,7 @@ void Adafruit_AM2320::setMinDelay(sensor_t* sensor) {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  create a temperature sensor instance
     @param parent the pointer to the parent sensor
     @param id the id value for the sensor
@@ -221,7 +234,7 @@ Adafruit_AM2320::Temperature::Temperature(Adafruit_AM2320* parent, int32_t id):
 {}
 
 /**************************************************************************/
-/*! 
+/*!
     @brief read the temperature from the device and populate a sensor_event_t with the value
     @param event a pointer to the event to populate
     @return true
@@ -236,12 +249,12 @@ bool Adafruit_AM2320::Temperature::getEvent(sensors_event_t* event) {
   event->type        = SENSOR_TYPE_AMBIENT_TEMPERATURE;
   event->timestamp   = millis();
   event->temperature = _parent->readTemperature();
-  
+
   return true;
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief populate a sensor_t with data for this sensor
     @param sensor a pointer to the sensor_t to populate
 */
@@ -265,7 +278,7 @@ void Adafruit_AM2320::Temperature::getSensor(sensor_t* sensor) {
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  create a humidity sensor instance
     @param parent the pointer to the parent sensor
     @param id the id value for the sensor
@@ -277,7 +290,7 @@ Adafruit_AM2320::Humidity::Humidity(Adafruit_AM2320* parent, int32_t id):
 {}
 
 /**************************************************************************/
-/*! 
+/*!
     @brief read the humidity from the device and populate a sensor_event_t with the value
     @param event a pointer to the event to populate
     @return true
@@ -292,12 +305,12 @@ bool Adafruit_AM2320::Humidity::getEvent(sensors_event_t* event) {
   event->type              = SENSOR_TYPE_RELATIVE_HUMIDITY;
   event->timestamp         = millis();
   event->relative_humidity = _parent->readHumidity();
-  
+
   return true;
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief populate a sensor_t with data for this sensor
     @param sensor a pointer to the sensor_t to populate
 */

--- a/Adafruit_AM2320.h
+++ b/Adafruit_AM2320.h
@@ -3,9 +3,9 @@
  *
  * This is a library for the AM2320 Temperature & Humidity Unified Sensor breakout board
  * ----> https://www.adafruit.com/products/xxxx
- * 
- * Adafruit invests time and resources providing this open source code, 
- * please support Adafruit and open-source hardware by purchasing 
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
  * Written by Limor Fried for Adafruit Industries.
@@ -42,14 +42,15 @@
 #include <Wire.h>
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Class that stores state and functions for interacting with AM2320 Temperature & Humidity Unified Sensor
 */
 /**************************************************************************/
 class Adafruit_AM2320 {
 public:
   Adafruit_AM2320(TwoWire *theI2C = &Wire, int32_t tempSensorId=-1, int32_t humiditySensorId=-1);
-  bool begin();
+  bool begin();                  /* Use default SDA and SCL pins */
+  bool begin(int sda, int scl);  /* Declare SDA and SCL pin locations here */
 
   float readTemperature();
   float readHumidity();
@@ -57,7 +58,7 @@ public:
   uint16_t crc16(uint8_t *buffer, uint8_t nbytes);
 
   /**************************************************************************/
-  /*! 
+  /*!
       @brief  temperature sensor class
   */
   /**************************************************************************/
@@ -73,7 +74,7 @@ public:
   };
 
   /**************************************************************************/
-  /*! 
+  /*!
       @brief  humidity sensor class
   */
   /**************************************************************************/
@@ -90,7 +91,7 @@ public:
   };
 
   /**************************************************************************/
-  /*! 
+  /*!
       @brief  get the temperature sensor object belonging to this class
       @return the temperature sensor object
   */
@@ -100,7 +101,7 @@ public:
   }
 
   /**************************************************************************/
-  /*! 
+  /*!
       @brief  get the humidity sensor object belonging to this class
       @return the humidity sensor object
   */

--- a/examples/basic_am2320_alt_pins/basic_am2320_alt_pins.ino
+++ b/examples/basic_am2320_alt_pins/basic_am2320_alt_pins.ino
@@ -1,0 +1,23 @@
+/* An exmaple of using alternate pins for SDA and SCL */
+
+#include "Adafruit_Sensor.h"
+#include "Adafruit_AM2320.h"
+
+Adafruit_AM2320 am2320 = Adafruit_AM2320();
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10); // hang out until serial port opens
+  }
+
+  Serial.println("Adafruit AM2320 Basic Test");
+  am2320.begin(D6,D5);  /* alternate SDA and SCL pins are declared here */
+}
+
+void loop() {
+  Serial.print("Temp: "); Serial.println(am2320.readTemperature());
+  Serial.print("Hum: "); Serial.println(am2320.readHumidity());
+
+  delay(2000);
+}


### PR DESCRIPTION
Modified code in Adafruit_AM2320.h and Adafruit_AM2320.cpp to allow the declaration of alternate SDA and SCL pins.

I found this functionality necessary when using a Wemos D1 Mini shield that uses the default SDA pin for another purpose, and also connecting the AM2320.
