### PR TITLE
Fix of begin method return value

### DIFF
--- a/Adafruit_AM2320.cpp
+++ b/Adafruit_AM2320.cpp
@@ -76,7 +76,7 @@ Adafruit_AM2320::Adafruit_AM2320(TwoWire *theI2C, int32_t tempSensorId,
     @return true
 */
 /**************************************************************************/
-bool Adafruit_AM2320::begin() { return i2c_dev->begin(); }
+bool Adafruit_AM2320::begin() { return i2c_dev->begin(false); }
 
 /**************************************************************************/
 /*!

--- a/Adafruit_AM2320.cpp
+++ b/Adafruit_AM2320.cpp
@@ -79,7 +79,6 @@ Adafruit_AM2320::Adafruit_AM2320(TwoWire *theI2C, int32_t tempSensorId,
 bool Adafruit_AM2320::begin() {
   if (!i2c_dev->begin(false))
     return false;
-  
   // sensor presence check
   i2c_dev->detected();        // wake up
   delay(10);                  // wait 10 ms

--- a/Adafruit_AM2320.cpp
+++ b/Adafruit_AM2320.cpp
@@ -76,7 +76,15 @@ Adafruit_AM2320::Adafruit_AM2320(TwoWire *theI2C, int32_t tempSensorId,
     @return true
 */
 /**************************************************************************/
-bool Adafruit_AM2320::begin() { return i2c_dev->begin(false); }
+bool Adafruit_AM2320::begin() {
+  if (!i2c_dev->begin(false))
+    return false;
+  
+  // sensor presence check
+  i2c_dev->detected(); // wake up
+  delay(10); // wait 10 ms
+  return i2c_dev->detected(); // check if ACK
+}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_AM2320.cpp
+++ b/Adafruit_AM2320.cpp
@@ -81,8 +81,8 @@ bool Adafruit_AM2320::begin() {
     return false;
   
   // sensor presence check
-  i2c_dev->detected(); // wake up
-  delay(10); // wait 10 ms
+  i2c_dev->detected();        // wake up
+  delay(10);                  // wait 10 ms
   return i2c_dev->detected(); // check if ACK
 }
 


### PR DESCRIPTION
Hi, I've noticed in my project that the begin method always returns false statement.

I've looked around the code and the begin method is returning a result of begin method from i2c_dev variable.
This variable stores the Adafruit_I2CDevice object. Its begin method has one parameter with default option true.
This option makes dicision if should be checked the device (AM2320 sensor) is present on I2C bus or the check should be skipped.
But there is the problem, all methods retrieving any data from sensor will contact it first to wake up sensor (the sensor will not answer ACK) then is possible to send a data request to sensor (the sensor will answer ACK at this time). The detection mentioned previously contacts the sensor once, not twice. It will result to fail of the check.

![obrazek](https://user-images.githubusercontent.com/78907070/164910389-5fd5c1a4-6c4c-46dc-b120-544307c7ecdf.png)

I've added the missing parameter to begin method, which disables the sensor presence check.

If it is needed, I can add right variant of the sensor presence check.

PS: In my project I have used NodeMCU v3 with chip ESP8266. Just for test I've written this code:

#include <Wire.h>
#include <Adafruit_Sensor.h>
#include <Adafruit_SPIDevice.h>
#include <Adafruit_I2CRegister.h>
#include <Adafruit_I2CDevice.h>
#include <Adafruit_BusIO_Register.h>
#include <Adafruit_AM2320.h>

Adafruit_AM2320 humidity_sensor;

void setup()
{
	Serial.begin(115200UL);
	Wire.begin(D4, D5);
	Wire.setClock(10000UL);

	Serial.println(humidity_sensor.begin(), DEC);
}

void loop()
{
	Serial.println(humidity_sensor.readHumidity());
	delay(5000UL);
}