### PR TITLE
Change data register read to 32 bits

### DIFF
--- a/Adafruit_AM2320.cpp
+++ b/Adafruit_AM2320.cpp
@@ -92,15 +92,15 @@ bool Adafruit_AM2320::begin() {
 */
 /**************************************************************************/
 float Adafruit_AM2320::readTemperature() {
-  uint16_t t = readRegister16(AM2320_REG_TEMP_H);
-  float ft;
-  if (t == 0xFFFF)
+  uint32_t data = readRegister32(AM2320_REG_HUM_H);
+  if (data == 0xFFFFFFFF)
     return NAN;
+  float ft;
   // check sign bit - the temperature MSB is signed , bit 0-15 are magnitude
-  if (t & 0x8000) {
-    ft = -(int16_t)(t & 0x7fff);
+  if (data & 0x8000) {
+    ft = -(int16_t)(data & 0x7FFF);
   } else {
-    ft = (int16_t)t;
+    ft = (int16_t)(data & 0xFFFF);
   }
   return ft / 10.0;
 }
@@ -112,23 +112,22 @@ float Adafruit_AM2320::readTemperature() {
 */
 /**************************************************************************/
 float Adafruit_AM2320::readHumidity() {
-  uint16_t h = readRegister16(AM2320_REG_HUM_H);
-  if (h == 0xFFFF)
+  uint32_t data = readRegister32(AM2320_REG_HUM_H);
+  if (data == 0xFFFFFFFF)
     return NAN;
 
-  float fh = h;
-  return fh / 10.0;
+  return (data >> 16) / 10.0;
 }
 
 /**************************************************************************/
 /*!
-    @brief  read 2 bytes from a hardware register
+    @brief  read 4 bytes from a hardware register
     @param reg the register to read
-    @return the read value as a 2 byte unsigned integer
+    @return the read value as a 4 byte unsigned integer
 */
 /**************************************************************************/
-uint16_t Adafruit_AM2320::readRegister16(uint8_t reg) {
-  uint8_t buffer[6] = {0, 0, 0, 0, 0, 0};
+uint32_t Adafruit_AM2320::readRegister32(uint8_t reg) {
+  uint8_t buffer[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
   // wake up
   i2c_dev->write(buffer, 1);
@@ -137,30 +136,31 @@ uint16_t Adafruit_AM2320::readRegister16(uint8_t reg) {
   // send a command to read register
   buffer[0] = AM2320_CMD_READREG;
   buffer[1] = reg;
-  buffer[2] = 2; // 2 bytes
+  buffer[2] = 4; // 4 bytes
   i2c_dev->write(buffer, 3);
   delay(2); // wait 2 ms
 
-  // 2 bytes preamble, 2 bytes data, 2 bytes CRC
-  i2c_dev->read(buffer, 6);
+  // 2 bytes preamble, 4 bytes data, 2 bytes CRC
+  i2c_dev->read(buffer, 8);
 
   if (buffer[0] != 0x03)
-    return 0xFFFF; // must be 0x03 modbus reply
-  if (buffer[1] != 2)
-    return 0xFFFF; // must be 2 bytes reply
+    return 0xFFFFFFFF; // must be 0x03 modbus reply
+  if (buffer[1] != 4)
+    return 0xFFFFFFFF; // must be 4 bytes reply
 
-  uint16_t the_crc = buffer[5];
+  uint16_t the_crc = buffer[7];
   the_crc <<= 8;
-  the_crc |= buffer[4];
-  uint16_t calc_crc = crc16(buffer, 4); // preamble + data
+  the_crc |= buffer[6];
+  uint16_t calc_crc = crc16(buffer, 6); // preamble + data
   // Serial.print("CRC: 0x"); Serial.println(calc_crc, HEX);
   if (the_crc != calc_crc)
-    return 0xFFFF;
+    return 0xFFFFFFFF;
 
   // All good!
-  uint16_t ret = buffer[2];
-  ret <<= 8;
-  ret |= buffer[3];
+  uint32_t ret = uint32_t(buffer[2]) << 24 |
+                 uint32_t(buffer[3]) << 16 |
+                 uint32_t(buffer[4]) << 8 |
+                 uint32_t(buffer[5]);
 
   return ret;
 }

--- a/Adafruit_AM2320.h
+++ b/Adafruit_AM2320.h
@@ -55,7 +55,7 @@ public:
 
   float readTemperature();
   float readHumidity();
-  uint16_t readRegister16(uint8_t reg);
+  uint32_t readRegister32(uint8_t reg);
   uint16_t crc16(uint8_t *buffer, uint8_t nbytes);
 
   /**************************************************************************/


### PR DESCRIPTION
There have been several reported cases of getting NAN returns when trying to use the AM2320 sensor:
https://forums.adafruit.com/viewtopic.php?p=971831
https://forums.adafruit.com/viewtopic.php?p=911247

This seems to be related to the two separate 16 bit register reads done for temperature and humidity.

This PR adds the fix that was suggested here:
https://forums.adafruit.com/viewtopic.php?p=911817#p911817
and reported as fixing the issue in those same threads.

Instead of separate 16 bit reads for temperature and humidity, both values are read in a single 32 bit read. The existing methods have been left in place. This makes the changes non-breaking, but is slightly inefficient since the "other" reading is thrown away.

Could not recreate the original issue locally. But PR was tested with an UNO and the `basic_am2320.ino` example sketch.
![Screenshot from 2023-05-08 16-08-29](https://user-images.githubusercontent.com/8755041/236957890-8840a7fc-2f02-49fc-b9ce-1f163974d9db.png)
