### PR TITLE
Fix I2C Error during wakeup, add retry logic

### DIFF
--- a/Adafruit_AM2320.cpp
+++ b/Adafruit_AM2320.cpp
@@ -133,11 +133,13 @@ uint32_t Adafruit_AM2320::readRegister32(uint8_t reg) {
   // wake up
   for (int i = 0; i < 3; i++) {
     written = i2c_dev->write(buffer, 1);
-    if(written) break;
+    if (written)
+      break;
     delay(100); // 50-70 lead to 2 errors each time
   }
-  if (!written) return 0xFFFFFFFF; // no ACK!
-  delay(10); // wait 10 ms
+  if (!written)
+    return 0xFFFFFFFF; // no ACK!
+  delay(10);           // wait 10 ms
 
   // send a command to read register
   buffer[0] = AM2320_CMD_READREG;
@@ -145,11 +147,13 @@ uint32_t Adafruit_AM2320::readRegister32(uint8_t reg) {
   buffer[2] = 4; // 4 bytes
   for (int i = 0; i < 3; i++) {
     written = i2c_dev->write(buffer, 3);
-    if(written) break;
+    if (written)
+      break;
     delay(5);
   }
-  if (!written) return 0xFFFFFFFF; // read not acknowledged!
-  delay(2); // wait 2 ms
+  if (!written)
+    return 0xFFFFFFFF; // read not acknowledged!
+  delay(2);            // wait 2 ms
 
   // 2 bytes preamble, 4 bytes data, 2 bytes CRC
   i2c_dev->read(buffer, 8);

--- a/Adafruit_AM2320.cpp
+++ b/Adafruit_AM2320.cpp
@@ -128,16 +128,27 @@ float Adafruit_AM2320::readHumidity() {
 /**************************************************************************/
 uint32_t Adafruit_AM2320::readRegister32(uint8_t reg) {
   uint8_t buffer[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  bool written = false;
 
   // wake up
-  i2c_dev->write(buffer, 1);
+  for (int i = 0; i < 3; i++) {
+    written = i2c_dev->write(buffer, 1);
+    if(written) break;
+    delay(100); // 50-70 lead to 2 errors each time
+  }
+  if (!written) return 0xFFFFFFFF; // no ACK!
   delay(10); // wait 10 ms
 
   // send a command to read register
   buffer[0] = AM2320_CMD_READREG;
   buffer[1] = reg;
   buffer[2] = 4; // 4 bytes
-  i2c_dev->write(buffer, 3);
+  for (int i = 0; i < 3; i++) {
+    written = i2c_dev->write(buffer, 3);
+    if(written) break;
+    delay(5);
+  }
+  if (!written) return 0xFFFFFFFF; // read not acknowledged!
   delay(2); // wait 2 ms
 
   // 2 bytes preamble, 4 bytes data, 2 bytes CRC


### PR DESCRIPTION
Fixes #13

I've had a quick test on an Adafruit ESP32 Feather v2 with the sensor connected to the StemmaQT / qwiic connector (i2c cable) and can confirm recreating the issue of `NaN` being returned for subsequent reads with no delay.

Adding the 100ms delay between reads gives me humidity too, but I see a spurious error on the first temperature reading with the basic example. The datasheet says to give 2seconds to stabilise after power-on, so adding a 2second wait at the end of setup removes the first temperature i2c #263 error, and the humidity errors remain, but the i2c bus detect does now show detected on the second call.

There is a similar report in circuitpython, with a 30ms delay minimum (I found that not enough in arduino). The datasheet mentions after having a read it will return to passive sleep mode until the next wake command, so it's possible we are attempting to communicate during this period.

I've increase the delay in readRegister32, from 10ms to 100ms upon failure, with a retry if the read command also fails.

The readings can now be called in a tight loop, and as expected they only change every two seconds.

@ladyada 